### PR TITLE
Add basic timeline UI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,51 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+posts = [
+    {
+        "id": 1,
+        "avatarUrl": "https://placekitten.com/80/80",
+        "displayName": "Cat Lover",
+        "username": "catlover",
+        "content": "Look at this cute kitten! 😺",
+        "timestamp": "1h",
+    },
+    {
+        "id": 2,
+        "avatarUrl": "https://placebear.com/80/80",
+        "displayName": "Bear Fan",
+        "username": "bearfan",
+        "content": "Bears are awesome!",
+        "timestamp": "2h",
+    },
+    {
+        "id": 3,
+        "avatarUrl": "https://placekitten.com/81/81",
+        "displayName": "Another Cat",
+        "username": "anothercat",
+        "content": "Sleeping all day...",
+        "timestamp": "3h",
+    },
+]
 
 @app.get("/")
 def read_root():
     return {"message": "AnimalBotSNS backend"}
+
+
+@app.get("/posts")
+def get_posts():
+    """Return a list of recent posts."""
+    return {"posts": posts}
 
 if __name__ == "__main__":
     import uvicorn

--- a/frontend/components/Post.tsx
+++ b/frontend/components/Post.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface PostProps {
+  avatarUrl: string;
+  displayName: string;
+  username: string;
+  content: string;
+  timestamp: string;
+}
+
+const Post: React.FC<PostProps> = ({ avatarUrl, displayName, username, content, timestamp }) => {
+  return (
+    <div style={{ display: 'flex', padding: '10px', borderBottom: '1px solid #e1e8ed' }}>
+      <img src={avatarUrl} alt={displayName} style={{ width: '48px', height: '48px', borderRadius: '50%', marginRight: '10px' }} />
+      <div style={{ flex: 1 }}>
+        <div style={{ marginBottom: '5px' }}>
+          <strong>{displayName}</strong> <span style={{ color: '#657786' }}>@{username}</span> · <span style={{ color: '#657786' }}>{timestamp}</span>
+        </div>
+        <div>{content}</div>
+      </div>
+    </div>
+  );
+};
+
+export default Post;

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,3 +1,39 @@
+import React from 'react';
+import Post from '../components/Post';
+
+const posts = [
+  {
+    id: 1,
+    avatarUrl: 'https://placekitten.com/80/80',
+    displayName: 'Cat Lover',
+    username: 'catlover',
+    content: 'Look at this cute kitten! 😺',
+    timestamp: '1h',
+  },
+  {
+    id: 2,
+    avatarUrl: 'https://placebear.com/80/80',
+    displayName: 'Bear Fan',
+    username: 'bearfan',
+    content: 'Bears are awesome!',
+    timestamp: '2h',
+  },
+  {
+    id: 3,
+    avatarUrl: 'https://placekitten.com/81/81',
+    displayName: 'Another Cat',
+    username: 'anothercat',
+    content: 'Sleeping all day...',
+    timestamp: '3h',
+  },
+];
+
 export default function Home() {
-  return <div>AnimalBotSNS Frontend</div>;
+  return (
+    <div style={{ maxWidth: '600px', margin: '0 auto', border: '1px solid #e1e8ed', borderRadius: '4px' }}>
+      {posts.map(post => (
+        <Post key={post.id} {...post} />
+      ))}
+    </div>
+  );
 }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,34 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Post from '../components/Post';
 
-const posts = [
-  {
-    id: 1,
-    avatarUrl: 'https://placekitten.com/80/80',
-    displayName: 'Cat Lover',
-    username: 'catlover',
-    content: 'Look at this cute kitten! 😺',
-    timestamp: '1h',
-  },
-  {
-    id: 2,
-    avatarUrl: 'https://placebear.com/80/80',
-    displayName: 'Bear Fan',
-    username: 'bearfan',
-    content: 'Bears are awesome!',
-    timestamp: '2h',
-  },
-  {
-    id: 3,
-    avatarUrl: 'https://placekitten.com/81/81',
-    displayName: 'Another Cat',
-    username: 'anothercat',
-    content: 'Sleeping all day...',
-    timestamp: '3h',
-  },
-];
+interface PostData {
+  id: number;
+  avatarUrl: string;
+  displayName: string;
+  username: string;
+  content: string;
+  timestamp: string;
+}
 
 export default function Home() {
+  const [posts, setPosts] = useState<PostData[]>([]);
+
+  useEffect(() => {
+    async function fetchPosts() {
+      try {
+        const res = await fetch('http://localhost:8000/posts');
+        const data = await res.json();
+        setPosts(data.posts);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchPosts();
+  }, []);
+
   return (
     <div style={{ maxWidth: '600px', margin: '0 auto', border: '1px solid #e1e8ed', borderRadius: '4px' }}>
       {posts.map(post => (

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -9,3 +9,12 @@ def test_read_root():
     response = client.get("/")
     assert response.status_code == 200
     assert response.json() == {"message": "AnimalBotSNS backend"}
+
+
+def test_get_posts():
+    response = client.get("/posts")
+    assert response.status_code == 200
+    data = response.json()
+    assert "posts" in data
+    assert isinstance(data["posts"], list)
+    assert data["posts"][0]["displayName"] == "Cat Lover"


### PR DESCRIPTION
## Summary
- create `Post` component for timeline entries
- build simple timeline page with sample posts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685178a978048332a2de51af341b3036